### PR TITLE
feat(api): add customers API endpoint

### DIFF
--- a/apps/accounting/api/serializers/serializers.py
+++ b/apps/accounting/api/serializers/serializers.py
@@ -13,7 +13,9 @@ from apps.accounting.models.disbursements import Disbursement
 from decimal import Decimal, ROUND_HALF_UP 
 from apps.accounting.models.pricing import ServiceSpecialPricing, ServiceStandardPricing
 from apps.clients.models.models import Client
+from apps.common.api.serializers import AddressSerializer
 from apps.companies.models import CompanyProfile, Company 
+from apps.companies.models.models import CompanyBranch
 from apps.individuals.models import Individual
 from apps.subscriptions.models.models import Services
 
@@ -910,3 +912,60 @@ class ServiceStandardPricingSerializer(serializers.ModelSerializer):
             'current_rate': instance.current_rate,
             'date_updated': date_updated
         }
+
+class CustomersSearchSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    full_name = serializers.SerializerMethodField()
+    phone = serializers.SerializerMethodField()
+    email = serializers.SerializerMethodField()
+    address = serializers.SerializerMethodField()
+    tin_number = serializers.SerializerMethodField()
+    vat_number = serializers.SerializerMethodField()
+
+    def get_full_name(self, obj):
+        if isinstance(obj, Individual):
+            return obj.full_name
+        elif isinstance(obj, CompanyBranch):
+            return obj.full_name
+        return None
+
+    def get_phone(self, obj):
+        if isinstance(obj, Individual):
+            return obj.phone or None
+        elif isinstance(obj, CompanyBranch):
+            profile = CompanyProfile.objects.filter(company=obj.company).first()
+            return obj.phone or (profile.landline_phone if profile else None) or None
+        return None
+
+    def get_email(self, obj):
+        if isinstance(obj, Individual):
+            return obj.email or None
+        elif isinstance(obj, CompanyBranch):
+            profile = CompanyProfile.objects.filter(company=obj.company).first()
+            return obj.email or (profile.email if profile else None) or None
+        return None
+
+    def get_tin_number(self, obj):
+        if isinstance(obj, Individual):
+            return None
+        elif isinstance(obj, CompanyBranch):
+            profile = CompanyProfile.objects.filter(company=obj.company).first()
+            return profile.tin_number if profile else None
+        return None
+    
+    def get_vat_number(self, obj):
+        if isinstance(obj, Individual):
+            return None
+        elif isinstance(obj, CompanyBranch):
+            profile = CompanyProfile.objects.filter(company=obj.company).first()
+            return profile.vat_number if profile else None
+        return None
+        
+    def get_address(self, obj):
+        if isinstance(obj, Individual):
+            address = obj.addresses.order_by('-id').first()
+            return AddressSerializer(address).data if address else None
+        elif isinstance(obj, CompanyBranch):
+            address = obj.primary_address if obj.primary_address else obj.company.addresses.order_by('-id').first()
+            return AddressSerializer(address).data if address else None
+        return None

--- a/apps/accounting/api/urls.py
+++ b/apps/accounting/api/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from apps.accounting.api.views import (
+    CustomersViewSet,
     SalesCategoryViewSet,
     SalesAccountViewSet,
     CashSaleViewSet,
@@ -45,6 +46,7 @@ router.register(r'transaction-types', TransactionTypeViewSet, basename="transact
 router.register(r'credit-notes', CreditNoteViewSet, basename="credit_notes")
 router.register(r'service-special-pricing', ServiceSpecialPricingViewSet, basename="service_special_pricing")
 router.register(r'service-standard-pricing', ServiceStandardPricingViewSet, basename="service_standard_pricing")
+router.register(r'customers', CustomersViewSet, basename="customers")
 urlpatterns = [
     path("", include(router.urls)),
     # path("detailed-general-ledger/", detailed_general_ledger ,name="detailed_general_ledger"),

--- a/apps/accounting/api/views.py
+++ b/apps/accounting/api/views.py
@@ -6,9 +6,10 @@ from rest_framework.filters import SearchFilter, OrderingFilter
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.exceptions import ValidationError
 from django.db.models import Q, Sum
+from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404
 from urllib import request
-from django.http import JsonResponse
+from django.http import Http404
 from rest_framework import viewsets,status
 from rest_framework.permissions import IsAuthenticated
 from apps.accounting.models.models import (
@@ -21,7 +22,7 @@ from apps.accounting.models.models import (
     CashBook,Currency,CreditNote,
 )
 from apps.accounting.api.serializers.serializers import (
-    SalesItemSerializer, ServiceSpecialPricingSerializer, ServiceStandardPricingSerializer,VATSettingSerializer,
+    CustomersSearchSerializer, SalesItemSerializer, ServiceSpecialPricingSerializer, ServiceStandardPricingSerializer,VATSettingSerializer,
     SalesCategorySerializer,SalesAccountSerializer,
     CashSaleSerializer, CashbookEntrySerializer,
     GeneralLedgerAccountSerializer, JournalEntrySerializer,
@@ -34,10 +35,14 @@ from apps.accounting.api.serializers.serializers import (
 from apps.accounting.models.pricing import ServiceSpecialPricing, ServiceStandardPricing
 from apps.common.api.views import BaseViewSet
 from apps.common.utils.helpers import extract_error_message
+from apps.companies.models.models import CompanyBranch
+from apps.individuals.models.models import Individual
 from apps.leases.models import Landlord
 from apps.clients.models import Client
 from apps.accounting.models.disbursements import Disbursement
 import logging
+
+from apps.leases.models.models import Lease
 
 logger = logging.getLogger('accounting')
 
@@ -441,3 +446,72 @@ class ServiceStandardPricingViewSet(BaseViewSet):
         except Exception as e:
             logger.error(f"Error updating standard pricing: {e}")
             return self._create_rendered_response({'error': "Something went wrong"}, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+class CustomersViewSet(BaseViewSet):
+    """ ViewSet to retrieve customers (tenants) associated with leases managed by the user's client."""
+    queryset = Lease.objects.none()
+    serializer_class = CustomersSearchSerializer
+
+    def get_queryset(self):
+        user = getattr(self.request, "user", None)
+        search_key = self.request.query_params.get('search', None)
+
+        if not user or not hasattr(user, 'client'):
+            return []
+
+        leases_qs = Lease.objects.filter(managing_client=user.client)
+
+        individual_ct = ContentType.objects.get(app_label="individuals", model="individual")
+        branch_ct = ContentType.objects.get(app_label="companies", model="companybranch")
+
+        individual_ids = leases_qs.filter(
+            leasetenantassociation__tenant__content_type=individual_ct
+        ).values_list('leasetenantassociation__tenant__object_id', flat=True)
+
+        branch_ids = leases_qs.filter(
+            leasetenantassociation__tenant__content_type=branch_ct
+        ).values_list('leasetenantassociation__tenant__object_id', flat=True)
+
+        ind_qs = Individual.objects.filter(id__in=individual_ids).distinct()
+        br_qs = CompanyBranch.objects.filter(id__in=branch_ids).distinct()
+
+        if search_key:
+            s = search_key.strip()
+            ind_qs = ind_qs.filter(
+                Q(identification_number__icontains=s) |
+                Q(first_name__icontains=s) |
+                Q(last_name__icontains=s)
+            )
+            br_qs = br_qs.filter(
+                Q(branch_name__icontains=s) |
+                Q(company__registration_name__icontains=s) |
+                Q(company__trading_name__icontains=s) |
+                Q(company__registration_number__icontains=s)
+            )
+
+        tenants = list(ind_qs) + list(br_qs)
+        seen = set()
+        unique_tenants = []
+        for t in tenants:
+            key = (t.__class__, t.pk)
+            if key not in seen:
+                seen.add(key)
+                unique_tenants.append(t)
+
+        return unique_tenants
+
+    def list(self, request, *args, **kwargs):
+        try:
+            queryset = self.get_queryset()
+            page = self.paginate_queryset(queryset)
+            if page is not None:
+                serializer = self.get_serializer(page, many=True)
+                return self.get_paginated_response(serializer.data)
+            serializer = self.get_serializer(queryset, many=True)
+            return self._create_rendered_response(serializer.data, status.HTTP_200_OK)
+        except Exception as e:
+            logger.error(f"Error retrieving customers: {e}")
+            return self._create_rendered_response(
+                {'error': "Something went wrong"}, 
+                status.HTTP_500_INTERNAL_SERVER_ERROR
+            )


### PR DESCRIPTION
Add a new CustomersViewSet in the accounting API to retrieve customers (tenants) associated with leases managed by the user's client. Includes a CustomersSearchSerializer for handling individual and company branch data, with support for search functionality. Updates imports, URLs, and views accordingly to enable the new endpoint.