### PR TITLE
Add diffrent responses output  in VAT (#290)

### DIFF
--- a/apps/accounting/api/views.py
+++ b/apps/accounting/api/views.py
@@ -160,10 +160,21 @@ class VATSettingViewSet(BaseViewSet):
                     valid_data.append(serializer.data)
                 else:
                     invalid_data.append(extract_error_message(serializer.errors))
-            return self._create_rendered_response(
-                {"created": valid_data, "errors": invalid_data},
-                status.HTTP_400_BAD_REQUEST,
-            )
+
+            if invalid_data and valid_data:
+                return self._create_rendered_response(
+                    {"created": valid_data, "errors": invalid_data},
+                    status.HTTP_207_MULTI_STATUS,
+                )
+            elif not invalid_data:
+                return self._create_rendered_response(
+                    valid_data, status.HTTP_201_CREATED
+                )
+            elif not valid_data:
+                return self._create_rendered_response(
+                    {"errors": invalid_data}, status.HTTP_400_BAD_REQUEST
+                )
+
         except ValidationError as e:
             logger.error(f"Validation error creating VAT setting: {e}")
             return self._create_rendered_response(


### PR DESCRIPTION
* feat(api): add search and filter functionality to company view

Add search and filter capabilities to the company API endpoint, allowing users to search by registration name, trading name, and registration number. Also added ordering functionality.

feat(db): enhance property and unit models

Significant improvements to the property and unit models:
- Added new status options (partially_occupied, vacant)
- Added managing_client relationship
- Improved model formatting and documentation
- Enhanced field descriptions and help text
- Added new unit type options
- Improved string formatting and code organization

* refactor(api): simplify account sector serialization

Simplified the GeneralLedgerAccountSerializer by replacing individual read-only fields for account sector name and code with a single SerializerMethodField. The new implementation returns a nested dictionary containing all account sector information when needed, improving code maintainability and reducing redundancy.

* fix(api): improve VAT setting creation response handling

Modify the VAT setting creation endpoint to return appropriate HTTP status codes based on the response content. When both valid and invalid data are present, return 207 MULTI_STATUS. When only valid data exists, return 201 CREATED. When only errors exist, return 400 BAD_REQUEST.