### PR TITLE
fixing phone number updating bugs

### DIFF
--- a/apps/individuals/admin.py
+++ b/apps/individuals/admin.py
@@ -91,7 +91,14 @@ class IndividualAccountsAdmin(admin.ModelAdmin):
 class EmploymentDetailInline(admin.TabularInline):
     model = EmploymentDetail
     extra = 0
-    fields = ("job_title", "employer_name", "industry", "start_date", "end_date", "is_current")
+    fields = (
+        "job_title",
+        "employer_name",
+        "industry",
+        "start_date",
+        "end_date",
+        "is_current",
+    )
     show_change_link = True
 
 
@@ -112,7 +119,7 @@ class NextOfKinInline(admin.TabularInline):
 class ContactDetailInline(admin.TabularInline):
     model = IndividualContactDetail
     extra = 0
-    fields = ("type", "phone_number")
+    fields = ("id", "type", "phone_number")
     show_change_link = True
 
 

--- a/apps/individuals/api/serializers.py
+++ b/apps/individuals/api/serializers.py
@@ -140,35 +140,24 @@ class ContactDetailsSerializer(serializers.ModelSerializer):
             phone_number=formatted
         ).first()
         if existing_contact:
-
             current_individual_id = (
                 getattr(self.instance, "individual_id", None)
                 or _get_parent_individual_id()
             )
-
-            if self.instance and existing_contact.pk == getattr(
-                self.instance, "pk", None
-            ):
-                data["phone_number"] = formatted
-                data["type"] = phone_type
-                return data
-
-            if (
-                current_individual_id
-                and existing_contact.individual_id == current_individual_id
-            ):
+            if existing_contact.individual.id != current_individual_id:
+                raise ValidationError(
+                    "This phone number is already registered to another individual"
+                )
+            else:
                 if existing_contact.type == phone_type:
                     raise ValidationError(
                         "Phone number already exists for this individual"
                     )
-                data["id"] = existing_contact.id
-                data["type"] = phone_type
-                data["phone_number"] = formatted
-                return data
-
-            raise ValidationError(
-                f"This phone number is already registered {formatted}"
-            )
+                else:
+                    data["id"] = existing_contact.id
+                    data["type"] = phone_type
+                    data["phone_number"] = formatted
+                    return data
 
         data["phone_number"] = formatted
         data["type"] = phone_type
@@ -295,6 +284,7 @@ class IndividualCreateSerializer(serializers.ModelSerializer):
     )
     date_of_birth = serializers.DateField(allow_null=True, required=False)
     account_data = IndividualAccountsSerializer(many=False, required=False)
+    phone = serializers.CharField(read_only=True)
 
     def to_internal_value(self, data):
         dob = data.get("date_of_birth")
@@ -321,6 +311,14 @@ class IndividualCreateSerializer(serializers.ModelSerializer):
             "phone",
             "account_data",
         ]
+
+    def get_phone(self, instance):
+        contact = (
+            instance.contact_details.filter(type="mobile").first()
+            or instance.contact_details.filter(type="combined").first()
+            or instance.contact_details.filter(type="whatsapp").first()
+        )
+        return contact.phone_number if contact else None
 
     def validate(self, data):
         id_type = data.get("identification_type")


### PR DESCRIPTION
Refactor phone number validation logic in ContactDetailsSerializer to use individual.id comparison instead of pk comparison, making it more robust and easier to understand. Add read-only phone field to IndividualCreateSerializer with corresponding get_phone method to return the primary mobile/contact number for an individual.

- Update EmploymentDetailInline and ContactDetailInline fields formatting for better readability
- Simplify validation flow and error messages in phone number uniqueness checks
- Expose phone number through serializer for API responses